### PR TITLE
Propagate context

### DIFF
--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -537,7 +537,7 @@ class sale_order(osv.osv):
                     continue
                 elif (line.state in states):
                     lines.append(line.id)
-            created_lines = obj_sale_order_line.invoice_line_create(cr, uid, lines)
+            created_lines = obj_sale_order_line.invoice_line_create(cr, uid, lines, context=context)
             if created_lines:
                 invoices.setdefault(o.partner_invoice_id.id or o.partner_id.id, []).append((o, created_lines))
         if not invoices:


### PR DESCRIPTION
Propagate context to _prepare_order_line_invoice_line().  This allows a module to override _prepare_invoice() and _prepare_order_line_invoice_line() and to pass context to those methods using sale_order.with_context(name=value).action_invoice_create().  This has no impact on invoice creation triggered from a workflow because workflows do not propagate context.